### PR TITLE
Add nodemailer transport parameter

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -1,6 +1,10 @@
 var nm = require("nodemailer");
 var utils = require('./utils.js');
-var t = nm.createTransport();
+var t = nm.createTransport({
+  tls: {
+    rejectUnauthorized: false
+  }
+});
 
 function sendAlert(stringerName, alertContent) {
   utils.readAsset('user-email.json', function(err, data) {


### PR DESCRIPTION
This now seems to be needed for the minimal sendmail config.

It may be that more params would be appropriate and should also be added, but this one seems to be needed at minimum.